### PR TITLE
Remove event listeners for non-existing events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,14 +60,10 @@ export default function Navaid(base, on404) {
 		}
 
 		addEventListener('popstate', run);
-		addEventListener('replacestate', run);
-		addEventListener('pushstate', run);
 		addEventListener('click', click);
 
 		$.unlisten = function () {
 			removeEventListener('popstate', run);
-			removeEventListener('replacestate', run);
-			removeEventListener('pushstate', run);
 			removeEventListener('click', click);
 		}
 


### PR DESCRIPTION
I don't think events `pushstate` or `replacestate` exist, so there's no point in adding event listeners for those?