### PR TITLE
fix: use import-star for regexparam

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import convert from 'regexparam';
+import * as convert from 'regexparam';
 
 export default function Navaid(base, on404) {
 	var rgx, curr, routes=[], $={};


### PR DESCRIPTION
ESBuild throws an error if you try to import a default export that does not exist.

This prevents Vite SSR users from using this library.